### PR TITLE
gitignore librecad backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.dxf~
+\#*.dxf
 *.FCBak
 *.FCStd1


### PR DESCRIPTION
librecad v2.2.0 (flatpak version) produces backup files with a hashtag # prefix, so we're ignoring them (before it was with a tilde suffix ~).